### PR TITLE
Byte to Uint8 instead of Int8

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -45,7 +45,7 @@ export function readFieldValue(buffer: Buffer, column: ColumnDefinition, db: Dat
 }
 
 function readByte(buffer: Buffer): number {
-    return buffer.readInt8();
+    return buffer.readUInt8();
 }
 
 function readInteger(buffer: Buffer): number {


### PR DESCRIPTION
I ran into some issues where all values above 128 turned negative on a column with byte type. 

If its the one or the other I would say that unsigned is likely most common.